### PR TITLE
Update Docker Compose for WebSocket logs

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -24,6 +24,9 @@ MAILER_PASSWORD = <mailer-password>
 FRONTEND_URL = http://host.docker.internal:3000
 AUTH_HTTP_PORT = 5000
 AUTH_GRPC_PORT = 5001
+WEBSOCKET_LOG_URL = ws://host.docker.internal:5002/live
+RUNNER_CONTROLLER_HTTP_PORT = 5002
+AUTH_GRPC_ADDRESS = host.docker.internal:5001
 
 RUNNER_CONTROLLER_HTTP_PORT = 5002
 AUTH_GRPC_ADDRESS = host.docker.internal:5001

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -117,6 +117,7 @@ services:
       MINIO_SECRET_KEY : ${MINIO_SECRET_KEY}
       RABBITMQ_URL : ${RABBITMQ_URL}
       RABBITMQ_QUEUE: ${RABBITMQ_QUEUE_NAME}
+      WEBSOCKET_LOG_URL: ${WEBSOCKET_LOG_URL}
 
   evolve_frontend:
     image: ghcr.io/evolutionary-algorithms-on-click/evolve_frontend:latest


### PR DESCRIPTION
Add configuration for WebSocket log URL in the Docker Compose file to enable live logging functionality.